### PR TITLE
buildx

### DIFF
--- a/buildx.sh
+++ b/buildx.sh
@@ -140,6 +140,7 @@ function push() {
   ( for i in $(seq 30); do sleep 60 && echo "hearthbeat: ${i}m"; done ) &
   pid1=$!
 
+  echo "BUILDPARAMS=${BUILDPARAMS[*]}"
   docker buildx build "${BUILDPARAMS[@]}" --push
 
   kill -9 "$pid1"

--- a/buildx.sh
+++ b/buildx.sh
@@ -50,7 +50,7 @@ function main() {
   sanitize "${INPUT_PASSWORD}" "password"
 
   REGISTRY_NO_PROTOCOL=${INPUT_REGISTRY#"https://"}
-  if uses "${INPUT_REGISTRY}" && ! isPartOfTheName "${REGISTRY_NO_PROTOCOL}"; then
+  if [ -n "$INPUT_REGISTRY" ] && ! isPartOfTheName "${REGISTRY_NO_PROTOCOL}"; then
     INPUT_NAME="${REGISTRY_NO_PROTOCOL}/${INPUT_NAME}"
   fi
 

--- a/docker.sh
+++ b/docker.sh
@@ -195,6 +195,6 @@ if ! docker buildx version ; then
   docker buildx version
 fi
 
-docker buildx create --use desktop-linux
+docker buildx create --use
 
 main

--- a/docker.sh
+++ b/docker.sh
@@ -179,7 +179,13 @@ function push() {
   do
     BUILD_TAGS="${BUILD_TAGS}--tag ${INPUT_NAME}:${TAG} "
   done
+
+  ( while :; do sleep 120 && echo hearthbeat; done ) &
+  pid1=$!
+
   docker buildx build ${INPUT_BUILDOPTIONS} ${BUILDPARAMS} ${BUILD_TAGS} ${CONTEXT} --push
+
+  kill -9 "$pid1"
 }
 
 # Enable buildkit

--- a/docker.sh
+++ b/docker.sh
@@ -179,7 +179,7 @@ function push() {
   do
     BUILD_TAGS="${BUILD_TAGS}--tag ${INPUT_NAME}:${TAG} "
   done
-  docker buildx build ${INPUT_BUILDOPTIONS} ${BUILDPARAMS} ${BUILD_TAGS} ${CONTEXT}
+  docker buildx build ${INPUT_BUILDOPTIONS} ${BUILDPARAMS} ${BUILD_TAGS} ${CONTEXT} --push
 }
 
 # Enable buildkit

--- a/docker.sh
+++ b/docker.sh
@@ -178,7 +178,7 @@ function push() {
   done
 
   # See travis_wait
-  ( while :; do sleep 120 && echo hearthbeat; done ) &
+  ( for i in $(seq 30); do sleep 60 && echo "hearthbeat: ${i}m"; done ) &
   pid1=$!
 
   INPUT_PLATFORM=${INPUT_PLATFORM:-"linux/amd64"}


### PR DESCRIPTION
New script `buildx.sh` to use `buildx` and `buildkit` to build multiplatform images.

- Add INPUT_PLATFORM defaults to `linux/amd64`
- cloned and adapted to keep `docker.sh`  and force the client repos to explicitly migrate to buildx.sh

Example usage in travis

```yaml
env:
  global:
    - INPUT_PLATFORM=linux/amd64,linux/arm64

after_success:
  - bash -c 'source <(curl -s https://raw.githubusercontent.com/adevinta/vulcan-cicd/master/buildx.sh)'
```

Allows the usage of `BUILDPLATFORM`, 'TARGETOS`, `TARGETARCH`, to improve the multiarch build. See an example:

```Dockerfile
FROM --platform=$BUILDPLATFORM  golang:1.19-alpine3.18 as builder

WORKDIR /app

COPY go.mod .
COPY go.sum .

RUN go mod download

COPY . .

ARG TARGETOS TARGETARCH

RUN GOOS=$TARGETOS GOARCH=$TARGETARCH go build .

FROM alpine:3.18

...
```