### PR TITLE
Dev

### DIFF
--- a/.github/workflows/approve-dependabot-pr.yml
+++ b/.github/workflows/approve-dependabot-pr.yml
@@ -20,11 +20,17 @@ jobs:
     - name: Fetch metadata
       id: metadata
       uses: dependabot/fetch-metadata@v1
-    - name: Approve and auto merge
-      if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+    - name: Auto merge and approve
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}
         GITHUB_TOKEN: ${{ secrets.PAT }}
+        UPDATE_TYPE: ${{ steps.metadata.outputs.update-type }}
+      shell: bash
       run: |
-        gh pr review --approve "$PR_URL"
-        gh pr merge --auto --squash --delete-branch "$PR_URL"
+        gh pr merge "$PR_URL" --auto --squash --delete-branch
+        if [[ "$UPDATE_TYPE" =~ version-update:(semver-patch|semver-minor) ]]; then
+          gh pr review "$PR_URL" --approve
+          gh pr comment "$PR_URL" --body "Approved \`$UPDATE_TYPE\` update"
+        else
+          gh pr comment "$PR_URL" --body "Skipping approval of \`$UPDATE_TYPE\` update"
+        fi


### PR DESCRIPTION
This pr improves the approval workflow

- It enables auto merge for all the dependabot PRs.
- It evaluates the update type and either approve it or creates a comment explaining why not.

With this change in order to merge a major update PR, it only has to be approved, and the merge will happen automatically.