### PR TITLE
fix release when major or minor tags exists

### DIFF
--- a/.github/workflows/reusable-release-dependabot-updates.yml
+++ b/.github/workflows/reusable-release-dependabot-updates.yml
@@ -28,7 +28,7 @@ jobs:
       id: history
       shell: bash
       run: |
-        LAST_TAG=$(git describe --tags --abbrev=0 || true)
+        LAST_TAG=$(git describe --tags --match="v[0-9]*.[0-9]*.[0-9]*" --abbrev=0 || true)
         if [ -z "$LAST_TAG" ]; then
             echo "No tags found, skipping"
             exit 0


### PR DESCRIPTION
In case of a repo with tags like 'v0' (like the ones generated by [vweevers/additional-tags-action](https://github.com/marketplace/actions/additional-tags) it computes a wrong next tag.
This fix filters those tags and only takes into consideration the full hotfix tags.